### PR TITLE
Fix unable to add receiver to transaction

### DIFF
--- a/src/SignhostAPIClient/Rest/DataObjects/Receiver.cs
+++ b/src/SignhostAPIClient/Rest/DataObjects/Receiver.cs
@@ -5,6 +5,10 @@ namespace Signhost.APIClient.Rest.DataObjects
 {
 	public class Receiver
 	{
+		public Receiver()
+		{
+		}
+		
 		[JsonConstructor]
 		private Receiver(IReadOnlyList<Activity> activities)
 		{


### PR DESCRIPTION
An empty constructor was missing which made it impossible to create an instance of a receiver to add this receiver to a transaction
