### PR TITLE
Make include netstandard 2.0 profile

### DIFF
--- a/src/SignhostAPIClient/Rest/StreamContentDigestOptionsExtensions.cs
+++ b/src/SignhostAPIClient/Rest/StreamContentDigestOptionsExtensions.cs
@@ -60,7 +60,7 @@ namespace Signhost.APIClient.Rest
 			string algorithmName = options.DigestHashAlgorithm;
 			HashAlgorithm algorithm = null;
 
-#if NETSTANDARD1_4
+#if NETSTANDARD1_4 || NETSTANDARD2_0
 			switch (algorithmName) {
 				case "SHA1":
 				case "SHA-1":
@@ -95,7 +95,7 @@ namespace Signhost.APIClient.Rest
 		}
 
 		private static HashAlgorithm DefaultHashAlgorithm() =>
-#if NETSTANDARD1_4
+#if NETSTANDARD1_4 || NETSTANDARD2_0
 			SHA256.Create();
 #else
 			HashAlgorithm.Create();

--- a/src/SignhostAPIClient/SignhostAPIClient.csproj
+++ b/src/SignhostAPIClient/SignhostAPIClient.csproj
@@ -31,12 +31,18 @@
     </PackageReleaseNotes>
     <Company>Evidos</Company>
     <Description>A .NET library for the signhost.com api.</Description>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     <InformationalVersion>$(VersionPrefix) $(VersionSufix)</InformationalVersion>
   </PropertyGroup>
   <ItemGroup Label="Build">
     <AdditionalFiles Include="../stylecop.json" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />

--- a/src/SignhostAPIClient/SignhostAPIClient.csproj
+++ b/src/SignhostAPIClient/SignhostAPIClient.csproj
@@ -1,9 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Build">
-    <TargetFrameworks>netstandard1.4;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.4;net45</TargetFrameworks>
     <CodeAnalysisRuleSet>../signhost.ruleset</CodeAnalysisRuleSet>
     <DefineConstants Condition="'$(TargetFramework)' == 'net45'">SERIALIZABLE</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)' == 'netstandard1.4'">TYPEINFO</DefineConstants>
+    <DefineConstants Condition="'$(TargetFramework)' == 'netstandard2.0'">TYPEINFO</DefineConstants>
+    <DefineConstants Condition="'$(TargetFramework)' == 'netstandard2.0'">SERIALIZABLE</DefineConstants>
     <RootNamespace>Signhost.APIClient</RootNamespace>
   </PropertyGroup>
   <PropertyGroup Label="Package">
@@ -38,14 +40,15 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta001" PrivateAssets="All" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Label=".NET 4.5 Package References" Condition="'$(TargetFramework)' == 'net45'">
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup Label=".NET standard Package References" Condition="'$(TargetFramework)' == 'netstandard1.4'">
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.*" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Only 4.5 and netstandard 1.4 targets were build. For the .net standard 2.0 we require less package references so these should be excluded for the 2.0 profile.