### PR TITLE
Added .NET Standard 2.0 target

### DIFF
--- a/src/SignhostAPIClient.Tests/SignhostAPIClient.Tests.csproj
+++ b/src/SignhostAPIClient.Tests/SignhostAPIClient.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Build">
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp2.0</TargetFrameworks>
     <CodeAnalysisRuleSet>../signhost.ruleset</CodeAnalysisRuleSet>
     <VersionSuffix>test</VersionSuffix>
   </PropertyGroup>
@@ -9,11 +9,10 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="FluentAssertions" Version="5.3.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="1.5.*" />
-    <PackageReference Include="xunit" Version="2.3.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="../SignhostAPIClient/SignhostAPIClient.csproj" />

--- a/src/SignhostAPIClient/SignhostAPIClient.csproj
+++ b/src/SignhostAPIClient/SignhostAPIClient.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Build">
-    <TargetFrameworks>netstandard1.4;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.4;net45</TargetFrameworks>
     <CodeAnalysisRuleSet>../signhost.ruleset</CodeAnalysisRuleSet>
     <DefineConstants Condition="'$(TargetFramework)' == 'net45'">SERIALIZABLE</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)' == 'netstandard1.4'">TYPEINFO</DefineConstants>
@@ -9,7 +9,7 @@
   <PropertyGroup Label="Package">
     <VersionBuildNumber Condition="'$(APPVEYOR_BUILD_NUMBER)' != ''">$(APPVEYOR_BUILD_NUMBER)</VersionBuildNumber>
     <VersionBuildNumber Condition="'$(VersionBuildNumber)' == ''">0</VersionBuildNumber>
-    <VersionPrefix>3.0.$(VersionBuildNumber)</VersionPrefix>
+    <VersionPrefix>4.0.$(VersionBuildNumber)</VersionPrefix>
     <VersionSuffix Condition="'$(VersionSuffix)' == ''">$(SH_VERSION_SUFFIX)</VersionSuffix>
     <Authors>Evidos</Authors>
     <Product>Signhost</Product>
@@ -19,6 +19,7 @@
     <PackageId>SignhostClientLibrary</PackageId>
     <PackageTags>sign;signing;digital signature;pdf</PackageTags>
     <PackageReleaseNotes>
+* 4.0.0 - Added .NET Standard 2.0 target
 * 3.0.0 - Bumped verifications support and added .net core target
 * 2.3.0 - Added support for custom forms creation over the API
 * 2.2.2 - Added basic parameter validation
@@ -37,15 +38,16 @@
     <AdditionalFiles Include="../stylecop.json" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta001" PrivateAssets="All" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup Label=".NET 4.5 Package References" Condition="'$(TargetFramework)' == 'net45'">
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup Label=".NET standard Package References" Condition="'$(TargetFramework)' == 'netstandard1.4'">
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.*" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
.NET Standard 2.0 provides a much simpler dependency graph for libraries targetting .NET Standard 2.0 and applications targetting .NET Core 2.0 or higher. It is the recommended framework to target, you might want to consider to drop the .NET Standard 1.4 target.

Some other changes:
- Update Json.NET package to the latest 11.0.2 release
- Move the `System.ValueTuple` package reference to .NET Standard 1.4 and .NET 4.5 `ItemGroup`. This package is included in .NET Standard 2.0 by default.
- Bumped the major version number
- Added .NET Core 2.1 target to the test project
- Update test packages