### PR TITLE
Fix AppVeyor errors originating from automatic update

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,13 +22,13 @@ before_build:
   - cmd: dotnet restore "src\SignhostAPIClient.sln
 
 build_script:
-  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER )                            { dotnet sonarscanner begin /k:"SignhostAPIClient" /d:"sonar.host.url=https://sonarcloud.io" /d:"sonar.organization=signhost" /d:"sonar.login=$env:sonarcloud_auth_token" /d:"sonar.cs.opencover.reportsPaths=src\SignhostAPIClient.Tests\result.cover" /d:"sonar.pullrequest.base=master" /d:"sonar.pullrequest.branch=PR-$env:APPVEYOR_PULL_REQUEST_NUMBER" /d:"sonar.pullrequest.key=$env:APPVEYOR_PULL_REQUEST_NUMBER" /d:"sonar.pullrequest.provider=GitHub" /d:"sonar.pullrequest.github.repository=Evidos/SignhostClientLibrary" }
-  - ps: if (-Not $env:APPVEYOR_PULL_REQUEST_NUMBER)                        { dotnet sonarscanner begin /k:"SignhostAPIClient" /d:"sonar.host.url=https://sonarcloud.io" /d:"sonar.organization=signhost" /d:"sonar.login=$env:sonarcloud_auth_token" /d:"sonar.cs.opencover.reportsPaths=src\SignhostAPIClient.Tests\result.cover" }
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER )                            { dotnet sonarscanner begin /key:"SignhostAPIClient" /d:"sonar.host.url=https://sonarcloud.io" /organization:"signhost" /d:"sonar.login=$env:sonarcloud_auth_token" /d:"sonar.cs.opencover.reportsPaths=src\SignhostAPIClient.Tests\result.cover" /d:"sonar.pullrequest.base=master" /d:"sonar.pullrequest.branch=PR-$env:APPVEYOR_PULL_REQUEST_NUMBER" /d:"sonar.pullrequest.key=$env:APPVEYOR_PULL_REQUEST_NUMBER" /d:"sonar.pullrequest.provider=GitHub" /d:"sonar.pullrequest.github.repository=Evidos/SignhostClientLibrary" }
+  - ps: if (-Not $env:APPVEYOR_PULL_REQUEST_NUMBER)                        { dotnet sonarscanner begin /key:"SignhostAPIClient" /d:"sonar.host.url=https://sonarcloud.io" /organization:"signhost" /d:"sonar.login=$env:sonarcloud_auth_token" /d:"sonar.cs.opencover.reportsPaths=src\SignhostAPIClient.Tests\result.cover" }
   - dotnet build "src\SignhostAPIClient.sln"
   - dotnet pack "src\SignhostAPIClient\SignhostAPIClient.csproj"
 
 test_script:
-  - dotnet test --no-build "src/SignhostAPIClient.Tests/SignhostAPIClient.Tests.csproj" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput="./result.cover"
+  - dotnet test --no-build "src/SignhostAPIClient.Tests/SignhostAPIClient.Tests.csproj" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput="./result.cover" /p:Exclude="[xunit*]*"
 
 after_test:
   - ps: dotnet sonarscanner end /d:"sonar.login=$env:sonarcloud_auth_token"; $LASTEXITCODE=0


### PR DESCRIPTION
Changes the way the `organization` parameter is provided, and excludes xunit. 