### PR TITLE
SIG-2616 Add obsolete marker to Kennisnet

### DIFF
--- a/src/SignhostAPIClient/Rest/DataObjects/KennisnetVerification.cs
+++ b/src/SignhostAPIClient/Rest/DataObjects/KennisnetVerification.cs
@@ -1,5 +1,8 @@
-﻿namespace Signhost.APIClient.Rest.DataObjects
+using System;
+
+namespace Signhost.APIClient.Rest.DataObjects
 {
+	[Obsolete("This verification is no longer supported and will be removed in SemVer 4.")]
 	public class KennisnetVerification
 		: IVerification
 	{


### PR DESCRIPTION
We can't remove Kennisnet until the next major version, so we mark it as obsolete until then.