### PR TITLE
SIG-5191 Downgrade FluentAssertions version to 7.2.0

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,13 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "FluentAssertions"
+      ],
+      "allowedVersions": "<8.0.0"
+    }
   ]
 }

--- a/src/SignhostAPIClient.Tests/SignhostAPIClient.Tests.csproj
+++ b/src/SignhostAPIClient.Tests/SignhostAPIClient.Tests.csproj
@@ -11,7 +11,7 @@
 
 	<ItemGroup Label="Package References">
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-		<PackageReference Include="FluentAssertions" Version="8.7.0" />
+		<PackageReference Include="FluentAssertions" Version="7.2.0" />
 		<PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />


### PR DESCRIPTION
v8.* requires a license, also adjusts the renovate.json package rules to avoid future bump PRs.